### PR TITLE
Cosmetic updates

### DIFF
--- a/src/components/TimelineVisualization.tsx
+++ b/src/components/TimelineVisualization.tsx
@@ -1778,6 +1778,25 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
         const [x0, y0] = points[i - 1];
         const [x1, y1] = points[i];
         
+        // Check if there's a corner at the next point when we're at i=1
+        // If so, skip the straight line segment and let the corner logic handle it at i=2
+        let skipStraightSegment = false;
+        if (i === 1 && points.length >= 3) {
+          const [x2, y2] = points[i + 1];
+          const dx0 = x1 - x0;
+          const dy0 = y1 - y0;
+          const dx1 = x2 - x1;
+          const dy1 = y2 - y1;
+          
+          // If there's a corner coming, skip the straight line
+          if ((dx0 === 0 && dy1 === 0 && dx1 !== 0) || (dy0 === 0 && dx1 === 0 && dy1 !== 0)) {
+            skipStraightSegment = true;
+            // Still update lastX/lastY to point[1] even though we skipped the segment,
+            // so the corner logic at i=2 sees the correct previous position
+            lastX = x1; lastY = y1;
+          }
+        }
+        
         // If direction changes (i.e., from horizontal to vertical or vice versa), round the corner
         if (i > 1) {
           const [xPrev, yPrev] = points[i - 2];
@@ -1811,8 +1830,11 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
           }
         }
         
-        segments.push({ type: 'L', coords: [x1, y1] });
-        lastX = x1; lastY = y1;
+        // Skip the straight line segment if we detected a corner is coming
+        if (!skipStraightSegment) {
+          segments.push({ type: 'L', coords: [x1, y1] });
+          lastX = x1; lastY = y1;
+        }
       }
       
       // Check if we ended at the target point
@@ -2308,11 +2330,17 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
         // Start at bar edge
         points.push([startX, startY]);
         // Short horizontal to clear the bar, then vertical to routing Y level
-        const xRouting = startX + vLaneSpacing + vLaneIdxStart * vLaneSpacing;
+        let xRouting = startX + vLaneSpacing + vLaneIdxStart * vLaneSpacing;
+        // Check if the lane offset would push us too far past the target
+        // If so, reduce it to avoid unnecessary back-and-forth routing
+        const xNearEnd = endX - vLaneSpacing - vLaneIdxEnd * vLaneSpacing;
+        if (xRouting > xNearEnd) {
+          // Lane offset is pushing us too far; reduce it
+          xRouting = startX + vLaneSpacing;
+        }
         points.push([xRouting, startY]);
         points.push([xRouting, routingY]);
         // Horizontal segment across to near the target
-        const xNearEnd = endX - vLaneSpacing - vLaneIdxEnd * vLaneSpacing;
         points.push([xNearEnd, routingY]);
         // Vertical down to target Y, then horizontal into target at exact edge
         points.push([xNearEnd, endY]);
@@ -2742,8 +2770,8 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
   {/* Prerequisites - completion */}
   <div onClick={() => setLayers(s => ({ ...s, prereqCompleted: !s.prereqCompleted }))} style={{ display: 'flex', gap: 8, alignItems: 'center', cursor: 'pointer', opacity: layers.prereqCompleted ? 1 : 0.4 }}>
           <svg width={16} height={16} viewBox="0 0 20 16">
-            <path d="M2 8 L18 8" stroke={kthColors.KthBlue?.HEX || '#004791'} strokeWidth={2} fill="none" />
-            <path d="M14 6 L18 8 L14 10" fill={kthColors.KthBlue?.HEX || '#004791'} />
+            <path d="M2 8 L16 8" stroke={kthColors.KthBlue?.HEX || '#004791'} strokeWidth={2} fill="none" />
+            <path d="M12 4 L20 8 L12 12" fill={kthColors.KthBlue?.HEX || '#004791'} />
           </svg>
           <span style={{ fontSize: 12, color: STYLE.legend.textColor }}>{tr[language].legend.prerequisitesCompleted}</span>
         </div>
@@ -2751,8 +2779,8 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
   {/* Prerequisites - participation */}
   <div onClick={() => setLayers(s => ({ ...s, prereqParticipation: !s.prereqParticipation }))} style={{ display: 'flex', gap: 8, alignItems: 'center', cursor: 'pointer', opacity: layers.prereqParticipation ? 1 : 0.4 }}>
           <svg width={16} height={16} viewBox="0 0 20 16">
-            <path d="M2 8 L18 8" stroke="#999" strokeWidth={2} strokeDasharray="4,3" fill="none" />
-            <path d="M14 6 L18 8 L14 10" fill="#999" />
+            <path d="M2 8 L16 8" stroke="#999" strokeWidth={2} strokeDasharray="4,3" fill="none" />
+            <path d="M12 4 L20 8 L12 12" fill="#999" />
           </svg>
           <span style={{ fontSize: 12, color: STYLE.legend.textColor }}>{tr[language].legend.prerequisitesParticipation}</span>
         </div>

--- a/src/components/TimelineVisualization.tsx
+++ b/src/components/TimelineVisualization.tsx
@@ -3147,7 +3147,7 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
                       y={barY + optionHeight / 2}
                       fontSize={11}
                       fontWeight={600}
-                      fill={kthColors.KthBrokenWhite?.HEX || '#FFFFFF'}
+                      fill={kthColors.KthMarine?.HEX || '#000061'}
                       dominantBaseline="central"
                     >
                       {optionCode} {optionName}, {totalCredits} {tr[language].credits}

--- a/src/components/TimelineVisualization.tsx
+++ b/src/components/TimelineVisualization.tsx
@@ -1760,7 +1760,7 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
       .attr('orient', 'auto')
       .append('path')
       .attr('d', 'M0,-5L10,0L0,5')
-      .attr('fill', kthColors.KthBlue?.HEX || '#004791');
+      .attr('fill', kthColors.KthHeaven?.HEX || '#6298D2');
 
     // Helper: create a rounded-corner SVG path from a polyline of only horizontal/vertical segments
     function roundedHVPolyline(points: [number, number][], radius: number) {
@@ -1902,7 +1902,7 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
           toYearIdx: firstCourse.year - 1,
           fromPeriod: lastPrereq.period,
           toPeriod: firstCourse.period,
-          style: { stroke: (kthColors.KthBlue?.HEX || '#004791'), markerId: 'arrow-blue', cssClass: 'prereq-completed' }
+          style: { stroke: (kthColors.KthHeaven?.HEX || '#6298D2'), markerId: 'arrow-blue', cssClass: 'prereq-completed' }
         });
       });
       
@@ -2770,8 +2770,8 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
   {/* Prerequisites - completion */}
   <div onClick={() => setLayers(s => ({ ...s, prereqCompleted: !s.prereqCompleted }))} style={{ display: 'flex', gap: 8, alignItems: 'center', cursor: 'pointer', opacity: layers.prereqCompleted ? 1 : 0.4 }}>
           <svg width={16} height={16} viewBox="0 0 20 16">
-            <path d="M2 8 L16 8" stroke={kthColors.KthBlue?.HEX || '#004791'} strokeWidth={2} fill="none" />
-            <path d="M12 4 L20 8 L12 12" fill={kthColors.KthBlue?.HEX || '#004791'} />
+            <path d="M2 8 L16 8" stroke={kthColors.KthHeaven?.HEX || '#6298D2'} strokeWidth={2} fill="none" />
+            <path d="M12 4 L20 8 L12 12" fill={kthColors.KthHeaven?.HEX || '#6298D2'} />
           </svg>
           <span style={{ fontSize: 12, color: STYLE.legend.textColor }}>{tr[language].legend.prerequisitesCompleted}</span>
         </div>

--- a/src/components/TimelineVisualization.tsx
+++ b/src/components/TimelineVisualization.tsx
@@ -96,33 +96,32 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
   const getFamilyVariants = (family: 'blue' | 'green' | 'turquoise' | 'brick' | 'yellow') => {
     if (family === 'blue') {
       return [
-        { fill: kthColors.KthMarine?.HEX || '#000061', stroke: kthColors.KthBlue?.HEX || '#004791', text: kthColors.KthLightBlue?.HEX || '#DEF0FF' },
-        { fill: kthColors.KthBlue?.HEX || '#004791', stroke: kthColors.KthMarine?.HEX || '#000061', text: kthColors.KthLightBlue?.HEX || '#DEF0FF' },
-        { fill: kthColors.KthHeaven?.HEX || '#6298D2', stroke: kthColors.KthMarine?.HEX || '#000061', text: kthColors.KthLightBlue?.HEX || '#DEF0FF' },
+        //{ fill: kthColors.KthHeaven?.HEX || '#6298D2', stroke: kthColors.KthMarine?.HEX || '#000061', text: kthColors.KthMarine?.HEX || '#000061' },
+        { fill: kthColors.KthLightBlue?.HEX || '#6298D2', stroke: kthColors.KthMarine?.HEX || '#000061', text: kthColors.KthMarine?.HEX || '#000061' },
       ];
     }
     if (family === 'green') {
       return [
-        { fill: kthColors.KthGreen?.HEX || '#4DA061', stroke: kthColors.KthDarkGreen?.HEX || '#0D4A21', text: kthColors.KthLightGreen?.HEX || '#C7EBBA' },
-        { fill: kthColors.KthDarkGreen?.HEX || '#0D4A21', stroke: kthColors.KthGreen?.HEX || '#4DA061', text: kthColors.KthLightGreen?.HEX || '#C7EBBA' },
+        //{ fill: kthColors.KthGreen?.HEX || '#4DA061', stroke: kthColors.KthDarkGreen?.HEX || '#0D4A21', text: kthColors.KthLightGreen?.HEX || '#C7EBBA' },
+        { fill: kthColors.KthLightGreen?.HEX || '#C7EBBA', stroke: kthColors.KthDarkGreen?.HEX || '#0D4A21', text: kthColors.KthLightGreen?.HEX || '#C7EBBA' },
       ];
     }
     if (family === 'turquoise') {
       return [
-        { fill: kthColors.KthTurquoise?.HEX || '#339C9C', stroke: kthColors.KthDarkTurquoise?.HEX || '#1C434C', text: kthColors.KthLightTurquoise?.HEX || '#B2E0E0' },
-        { fill: kthColors.KthDarkTurquoise?.HEX || '#1C434C', stroke: kthColors.KthTurquoise?.HEX || '#339C9C', text: kthColors.KthLightTurquoise?.HEX || '#B2E0E0' },
+        //{ fill: kthColors.KthTurquoise?.HEX || '#339C9C', stroke: kthColors.KthDarkTurquoise?.HEX || '#1C434C', text: kthColors.KthLightTurquoise?.HEX || '#B2E0E0' },
+        { fill: kthColors.KthLightTurquoise?.HEX || '#B2E0E0', stroke: kthColors.KthDarkTurquoise?.HEX || '#1C434C', text: kthColors.KthLightTurquoise?.HEX || '#B2E0E0' },
       ];
     }
     if (family === 'brick') {
       return [
-        { fill: kthColors.KthBrick?.HEX || '#E86A58', stroke: kthColors.KthDarkBrick?.HEX || '#78001A', text: kthColors.KthLightBrick?.HEX || '#FFCCC4' },
-        { fill: kthColors.KthDarkBrick?.HEX || '#78001A', stroke: kthColors.KthBrick?.HEX || '#E86A58', text: kthColors.KthLightBrick?.HEX || '#FFCCC4' },
+        //{ fill: kthColors.KthBrick?.HEX || '#E86A58', stroke: kthColors.KthDarkBrick?.HEX || '#78001A', text: kthColors.KthDarkBrick?.HEX || '#78001A' },
+        { fill: kthColors.KthLightBrick?.HEX || '#FFCCC4', stroke: kthColors.KthDarkBrick?.HEX || '#78001A', text: kthColors.KthDarkBrick?.HEX || '#78001A' },
       ];
     }
     // yellow
     return [
-      { fill: kthColors.KthYellow?.HEX || '#FFBE00', stroke: kthColors.KthDarkYellow?.HEX || '#A65900', text: kthColors.KthLightYellow?.HEX || '#FFF0B0' },
-      { fill: kthColors.KthDarkYellow?.HEX || '#A65900', stroke: kthColors.KthYellow?.HEX || '#FFBE00', text: kthColors.KthLightYellow?.HEX || '#FFF0B0' },
+      //{ fill: kthColors.KthYellow?.HEX || '#FFBE00', stroke: kthColors.KthDarkYellow?.HEX || '#A65900', text: kthColors.KthDarkYellow?.HEX || '#A65900' },
+      { fill: kthColors.KthLightYellow?.HEX || '#FFF0B0', stroke: kthColors.KthDarkYellow?.HEX || '#A65900', text: kthColors.KthDarkYellow?.HEX || '#A65900' },
     ];
   };
 
@@ -338,16 +337,19 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
               c.setAttribute('cx', '9');
               c.setAttribute('cy', String(itemHeight/2));
               c.setAttribute('r', '6');
-              c.setAttribute('fill', kthColors.KthBrick?.HEX || '#E86A58');
+              c.setAttribute('fill', kthColors.KthLightBrick?.HEX || '#FFCCC4');
+              c.style.stroke = kthColors.KthDarkBrick?.HEX || '#B35A4A';
+              c.style.strokeWidth = '1.5';
               rowG.appendChild(c);
             } else if (item.type === 'reexam') {
               const c = document.createElementNS(NS, 'circle');
               c.setAttribute('cx', '9');
               c.setAttribute('cy', String(itemHeight/2));
               c.setAttribute('r', '6');
-              c.setAttribute('fill', 'none');
-              c.setAttribute('stroke', kthColors.KthBrick?.HEX || '#E86A58');
-              c.setAttribute('stroke-width', '1.5');
+              c.setAttribute('fill', kthColors.KthLightBrick?.HEX || '#FFCCC4');
+              c.style.stroke = kthColors.KthDarkBrick?.HEX || '#B35A4A';
+              c.style.strokeWidth = '1.5';
+              c.style.strokeDasharray = '3 2';
               rowG.appendChild(c);
             } else if (item.type === 'prereqCompleted') {
               const line = document.createElementNS(NS, 'line');
@@ -1565,7 +1567,7 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
               .attr('cy', circleCenterY)
               .attr('r', circleRadius)
               .attr('fill', 'none')
-              .attr('stroke', kthColors.KthBrokenWhite?.HEX || '#FFFFFF')
+              .attr('stroke', kthColors.KthMarine?.HEX || '#000061')
               .attr('stroke-width', 1.5)
               .attr('pointer-events', 'none');
             
@@ -1577,7 +1579,7 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
               .attr('dominant-baseline', 'central')
               .attr('font-size', 10)
               .attr('font-weight', 600)
-              .attr('fill', kthColors.KthBrokenWhite?.HEX || '#FFFFFF')
+              .attr('fill', kthColors.KthMarine?.HEX || '#000061')
               .attr('pointer-events', 'none')
               .text(numOptions);
             
@@ -1607,7 +1609,7 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
             .attr('y', textY)
             .attr('font-size', 11)
             .attr('font-weight', 600)
-            .attr('fill', kthColors.KthBrokenWhite?.HEX || '#FFFFFF')
+            .attr('fill', kthColors.KthMarine?.HEX || '#000061')
             .attr('pointer-events', 'none')
             .attr('class', 'course-label')
             .text(fullText);
@@ -1795,9 +1797,17 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
             
             segments.push({ type: 'L', coords: [prevX, prevY] });
             lastX = prevX; lastY = prevY;
-            segments.push({ type: 'Q', coords: [x0, y0, nextX, nextY] });
-            lastX = nextX; lastY = nextY;
-            continue;
+            if (i === points.length - 1) {
+              // Last corner: curve directly into the exact target
+              segments.push({ type: 'Q', coords: [x0, y0, x1, y1] });
+              lastX = x1; lastY = y1;
+              continue;
+            } else {
+              // Intermediate corner: curve to shortened point
+              segments.push({ type: 'Q', coords: [x0, y0, nextX, nextY] });
+              lastX = nextX; lastY = nextY;
+              continue;
+            }
           }
         }
         
@@ -1808,45 +1818,9 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
       // Check if we ended at the target point
       const [targetX, targetY] = points[points.length - 1];
       
-      // If we're short of the target, adjust the last horizontal segment instead of adding a backward line
+      // If we're short of the target, append a final segment to reach target exactly
       if (lastX !== targetX || lastY !== targetY) {
-        // Find the last horizontal segment (L command where Y doesn't change from previous point)
-        let adjusted = false;
-        for (let i = segments.length - 1; i >= 1; i--) {
-          if (segments[i].type === 'L') {
-            const prevSeg = segments[i - 1];
-            let prevY: number;
-            
-            if (prevSeg.type === 'L') {
-              prevY = prevSeg.coords[1];
-            } else if (prevSeg.type === 'Q') {
-              prevY = prevSeg.coords[3]; // quadratic ends at coords[2], coords[3]
-            } else if (prevSeg.type === 'M') {
-              prevY = prevSeg.coords[1];
-            } else {
-              continue;
-            }
-            
-            const thisY = segments[i].coords[1];
-            
-            // Is this a horizontal segment (same Y)?
-            if (Math.abs(thisY - prevY) < 0.1 && thisY === targetY) {
-              // Adjust this horizontal segment to end at targetX
-              segments[i].coords[0] = targetX;
-              adjusted = true;
-              break;
-            }
-          }
-        }
-        
-        // If we couldn't adjust a horizontal segment, only add final L if it goes forward
-        if (!adjusted) {
-          const wouldGoForward = (targetX > lastX && Math.abs(targetY - lastY) < 0.1) || 
-                                 (targetY !== lastY && targetX === lastX);
-          if (wouldGoForward) {
-            segments.push({ type: 'L', coords: [targetX, targetY] });
-          }
-        }
+        segments.push({ type: 'L', coords: [targetX, targetY] });
       }
       
       // Convert segments to path string
@@ -2288,7 +2262,7 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
       const vPad = 8;
       const curveR = 8;
       const laneSpacing = 4;
-      const vLaneSpacing = 4;
+      const vLaneSpacing = 7;
 
       const isSameYear = arrow.fromYearIdx === arrow.toYearIdx;
       const fromPeriodNum = periodOrder[arrow.fromPeriod];
@@ -2445,9 +2419,10 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
       .attr('cx', m.x)
       .attr('cy', m.cy)
       .attr('r', REEXAM_MARKER_RADIUS)
-      .attr('fill', 'none')
+      .attr('fill', colors.fill)
       .attr('stroke', colors.stroke)
       .attr('stroke-width', REEXAM_MARKER_STROKE_WIDTH)
+      .attr('stroke-dasharray', '2 2')
       .style('pointer-events', 'auto')
       .attr('class', 'reexam-dot')
       .attr('data-layer', 'reexams')
@@ -2751,7 +2726,7 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
         {/* Exams */}
         <div onClick={() => setLayers(s => ({ ...s, exams: !s.exams }))} style={{ display: 'flex', gap: 8, alignItems: 'center', cursor: 'pointer', opacity: layers.exams ? 1 : 0.4 }}>
           <svg width={16} height={16} viewBox="0 0 16 16">
-            <circle cx={8} cy={8} r={6} fill={kthColors.KthBrick?.HEX || '#E86A58'} stroke={kthColors.KthDarkBrick?.HEX || '#78001A'} strokeWidth={1.5}/>
+            <circle cx={8} cy={8} r={6} fill={kthColors.KthLightBrick?.HEX || '#FFCCC4'} stroke={kthColors.KthDarkBrick?.HEX || '#B35A4A'} strokeWidth={1.5}/>
           </svg>
           <span style={{ fontSize: 12, color: STYLE.legend.textColor }}>{tr[language].legend.exams}</span>
         </div>
@@ -2759,7 +2734,7 @@ const TimelineVisualization = forwardRef(function TimelineVisualization({ course
         {/* Reexams */}
         <div onClick={() => setLayers(s => ({ ...s, reexams: !s.reexams }))} style={{ display: 'flex', gap: 8, alignItems: 'center', cursor: 'pointer', opacity: layers.reexams ? 1 : 0.4 }}>
           <svg width={16} height={16} viewBox="0 0 16 16">
-            <circle cx={8} cy={8} r={6} fill="none" stroke={kthColors.KthBrick?.HEX || '#E86A58'} strokeWidth={1.5} />
+            <circle cx={8} cy={8} r={6} fill={kthColors.KthLightBrick?.HEX || '#FFCCC4'} stroke={kthColors.KthDarkBrick?.HEX || '#B35A4A'} strokeWidth={1.5} strokeDasharray="3 2" />
           </svg>
           <span style={{ fontSize: 12, color: STYLE.legend.textColor }}>{tr[language].legend.reexams}</span>
         </div>


### PR DESCRIPTION
- Reducing the number of colors used for the course bars, only using one light color in each group, and because of that changing the text to a dark marine instead of broken white for visibility. 
- Improved exam markers, they all have a fill color now, but the reexam markers have dashed outlines. 
- The arrow routing for prerequisites is improved, making sure arrows stop with their tip exactly at the start of the target course bar, and spurious straight segments at the start of many arrows is finally gone. Also adjusted the color for the completed-course prerequisite arrows, for softer visual impression.