### PR TITLE
Hiding unvalidated study plans by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1042,9 +1042,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -1074,9 +1074,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -1090,11 +1090,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1106,11 +1109,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1122,11 +1128,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1138,11 +1147,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1154,9 +1166,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -1170,9 +1182,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -6280,12 +6292,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -6299,14 +6311,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/scripts/validate-data.mjs
+++ b/scripts/validate-data.mjs
@@ -8,7 +8,7 @@
 // Schema (informal):
 //
 // programs.json:
-//   Array<{ code, name, nameEn?, dataFile, cosmeticsFile?, comment?,
+//   Array<{ code, name, nameEn?, dataFile, cosmeticsFile?, verified?, comment?,
 //           commentEn?, studyplan?,
 //           specializations?: Array<{ code, name, nameEn?, group? }>,
 //           specializationGroups?: Array<{ code, name, nameEn? }> }>
@@ -107,6 +107,10 @@ function validateProgramsJson(programs, file) {
     }
     if (p.cosmeticsFile && !existsSync(join(dataDir, p.cosmeticsFile))) {
       err(file, `${ctx} ${p.code}: cosmeticsFile '${p.cosmeticsFile}' not found`);
+    }
+
+    if (p.verified !== undefined && typeof p.verified !== 'boolean') {
+      err(file, `${ctx} ${p.code}: 'verified' must be a boolean if present`);
     }
 
     // Specialization groups (optional). When present, every group must

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -37,6 +37,11 @@ interface ProgramConfig {
   nameEn?: string;
   dataFile: string;
   cosmeticsFile?: string;
+  // Whether the study plan has been verified by the program director or
+  // admin personnel. Unverified plans are hidden from the program-selector
+  // dropdown unless the user opts in via the "show unverified" checkbox.
+  // Missing field is treated as `false`.
+  verified?: boolean;
   comment?: string;
   // Optional English-language comment shown when the page language is `en`.
   // Falls back to `comment` if missing — keeps existing entries valid.
@@ -67,6 +72,8 @@ const ui = {
     swedish: 'Svenska',
     english: 'Engelska',
     menu: 'Meny för export och språk',
+    showUnverified: 'Visa icke-verifierade utbildningsplaner',
+    unverifiedSuffix: '(inte verifierad)',
   },
   en: {
     title: 'Education program visualization',
@@ -80,6 +87,8 @@ const ui = {
     swedish: 'Swedish',
     english: 'English',
     menu: 'Export and language menu',
+    showUnverified: 'Show unverified study plans',
+    unverifiedSuffix: '(unverified)',
   }
 } as const;
 
@@ -108,11 +117,31 @@ export default function HomeClient() {
     return (langParam === 'en' || langParam === 'sv') ? langParam : 'sv';
   }, [searchParams]);
 
+  // Whether unverified study plans are shown in the program dropdown.
+  // Off by default; flipped via the checkbox next to the selector.
+  // Persisted in the URL as `unverified=1` so bookmarks survive reloads.
+  const showUnverified = useMemo<boolean>(() => searchParams.get('unverified') === '1', [searchParams]);
+
   const setLanguage = (lang: Lang) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set('l', lang);
     router.replace(`/?${params.toString()}`);
   };
+
+  const setShowUnverified = (next: boolean) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next) params.set('unverified', '1');
+    else params.delete('unverified');
+    router.replace(`/?${params.toString()}`);
+  };
+
+  // Always include the currently-selected program even if it's unverified
+  // and the toggle is off — otherwise a bookmarked `?program=CTMAT` would
+  // hide its own entry from the dropdown and silently look broken.
+  const visiblePrograms = useMemo<ProgramConfig[]>(() => {
+    if (showUnverified) return programs;
+    return programs.filter(p => p.verified === true || p.code === selectedProgram.code);
+  }, [showUnverified, selectedProgram]);
 
   // ----- View state derived from URL params -----
   // og=Group1:Code1,Group2:Code2 — user's pick per option group
@@ -279,7 +308,7 @@ export default function HomeClient() {
           <h1 className="text-3xl font-bold" style={{ color: kthColors.KthHeaven?.HEX }}>{ui[language].title}</h1>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
             <label style={{ color: kthColors.KthBlue?.HEX, fontWeight: 600 }}>{ui[language].programLabel}</label>
-            <select 
+            <select
             value={selectedProgram.code}
             onChange={(e) => {
               const program = programs.find(p => p.code === e.target.value);
@@ -292,11 +321,21 @@ export default function HomeClient() {
             style={{ color: kthColors.KthBlue?.HEX }}
             className="px-4 py-2 border border-gray-300 rounded-md shadow-sm"
           >
-            {programs.map(program => (
-              <option key={program.code} value={program.code}>{program.code}</option>
+            {visiblePrograms.map(program => (
+              <option key={program.code} value={program.code}>
+                {program.verified === true ? program.code : `${program.code} ${ui[language].unverifiedSuffix}`}
+              </option>
             ))}
           </select>
-          
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6, color: kthColors.KthBlue?.HEX, fontSize: 13 }}>
+              <input
+                type="checkbox"
+                checked={showUnverified}
+                onChange={(e) => setShowUnverified(e.target.checked)}
+              />
+              {ui[language].showUnverified}
+            </label>
+
             <div style={{ position: 'relative' }}>
               <button ref={exportBtnRef} onClick={() => setMenuOpen(v => !v)} className="px-2 py-2 border border-gray-300 rounded-md shadow-sm" aria-label={ui[language].menu} aria-expanded={menuOpen} aria-haspopup="menu">
                 <svg width="20" height="16" viewBox="0 0 20 16" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/data/programs.json
+++ b/src/data/programs.json
@@ -5,6 +5,7 @@
     "nameEn": "Degree Program in Engineering Physics",
     "dataFile": "CTFYS.json",
     "cosmeticsFile": "CTFYS-cosmetics.json",
+    "verified": true,
     "comment": "Utbildningsplanen verifierad av programansvarig Christian Ohm i november 2025",
     "commentEn": "Study plan verified by program director Christian Ohm in November 2025",
     "studyplan": "https://www.kth.se/student/kurser/program/CTFYS"
@@ -15,6 +16,7 @@
     "nameEn": "Degree Program in Engineering Mathematics",
     "dataFile": "CTMAT.json",
     "cosmeticsFile": "CTMAT-cosmetics.json",
+    "verified": false,
     "comment": "Utbildningsplanen är ännu inte verifierad - använd med försiktighet!",
     "commentEn": "Study plan not yet verified — use with caution!",
     "studyplan": "https://www.kth.se/student/kurser/program/CTMAT"
@@ -25,6 +27,7 @@
     "nameEn": "Degree Program in Vehicle Engineering",
     "dataFile": "CFATE.json",
     "cosmeticsFile": "CFATE-cosmetics.json",
+    "verified": false,
     "comment": "Utbildningsplanen är ännu inte verifierad - använd med försiktighet!",
     "commentEn": "Study plan not yet verified — use with caution!",
     "studyplan": "https://www.kth.se/student/kurser/program/CFATE"
@@ -36,6 +39,7 @@
     "nameEn": "Degree Program in Engineering - Open Entrance",
     "dataFile": "COPEN.json",
     "cosmeticsFile": "COPEN-cosmetics.json",
+    "verified": false,
     "comment": "Utbildningsplanen är ännu inte verifierad - använd med försiktighet!",
     "commentEn": "Study plan not yet verified — use with caution!",
     "studyplan": "https://www.kth.se/student/kurser/program/COPEN"
@@ -46,6 +50,7 @@
     "nameEn": "Degree Program in Industrial Engineering and Management",
     "dataFile": "CINEK.json",
     "cosmeticsFile": "CINEK-cosmetics.json",
+    "verified": false,
     "comment": "Hämtad automatiskt från KTH studiehandbok 2024-cohort, ej manuellt verifierad. Y4-Y5 ligger i masterprogrammen och visas inte här.",
     "commentEn": "Auto-scraped from the KTH study handbook (2024 cohort), not manually verified. Y4-Y5 live in the master programmes and are not shown here.",
     "studyplan": "https://www.kth.se/student/kurser/program/CINEK",
@@ -62,6 +67,7 @@
     "nameEn": "Master's Programme, Industrial Engineering and Management",
     "dataFile": "TIEMM.json",
     "cosmeticsFile": "TIEMM-cosmetics.json",
+    "verified": false,
     "comment": "Masterprogram (motsvarar år 4-5 av civilingenjörsprogrammet CINEK). Hämtad automatiskt från KTH studiehandbok 2024-cohort, ej manuellt verifierad. Spår modelleras tills vidare som specializations i samma fält.",
     "commentEn": "Master programme (corresponds to year 4-5 of the CINEK degree program). Auto-scraped from the KTH study handbook (2024 cohort), not manually verified. Tracks (spår) are temporarily modelled in the same `specializations` field.",
     "studyplan": "https://www.kth.se/student/kurser/program/TIEMM",


### PR DESCRIPTION
What the title says. Some details:
- `src/data/programs.json` — added `"verified": true` to CTFYS, `"verified": false` to the five preliminary plans.
- `src/app/HomeClient.tsx` — extended ProgramConfig with verified?: boolean, added showUnverified derived from `?unverified=1`, `setShowUnverified, and a `visiblePrograms` list that filters by verified status. Added the checkbox next to the program dropdown and the "(inte verifierad)" / "(unverified)" suffix on unverified entries.
- scripts/validate-data.mjs — schema comment and a runtime check that verified is a boolean when present.

Behavior:
- Default load: only CTFYS appears in the dropdown.
- Checking the box exposes the others, each labelled e.g. CTMAT (inte verifierad); state persists in the URL as `?unverified=1`.
- A bookmarked `?program=CTMAT` still shows CTMAT in the dropdown even with the box off, so the selector never hides its own current value (you can switch back to CTFYS from there).
